### PR TITLE
Expose img_util in package namespace

### DIFF
--- a/basket_viz/__init__.py
+++ b/basket_viz/__init__.py
@@ -1,0 +1,8 @@
+"""Top-level package for :mod:`basket_viz`."""
+
+from importlib import import_module
+
+img_util = import_module(".img_util", __name__)
+
+__all__ = ["img_util"]
+


### PR DESCRIPTION
## Summary
- expose the img_util subpackage from the top-level basket_viz package
- advertise the new export via __all__ so ``from basket_viz import img_util`` works

## Testing
- PYTHONPATH=. python - <<'PY'
from basket_viz import img_util
print(img_util.__name__)
PY


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69125b21fe00832bb0f0fbd8da91e5a5)