### PR TITLE
Add seaborn dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ python-dotenv>=0.5.1
 matplotlib==3.7.1
 pandas==2.0.3
 Pillow==9.5.0
+seaborn==0.12.2
 requests==2.26.0
 numpy==1.21.0


### PR DESCRIPTION
## Summary
- add seaborn to the Python dependencies list for visualization support

## Testing
- pip install seaborn==0.12.2 *(fails in this environment because the package index cannot be reached through the proxy)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6921bfe62c30832b874c432c8f09873d)