### PR TITLE
Add heatmap label toggle and bump version

### DIFF
--- a/basket_viz/stat_grid/season_stats.py
+++ b/basket_viz/stat_grid/season_stats.py
@@ -95,6 +95,7 @@ class PlayerStatsHeatmap:
         stat="Points",
         team_logo_url_lst=None,
         show=True,
+        show_labels=True,
     ):
         """
         Plot the heatmap of the specified stat for the players.
@@ -120,6 +121,8 @@ class PlayerStatsHeatmap:
             chaining with :meth:`add_bottom_images`, prefer ``show=False`` and
             call ``plt.show()`` once after the logos are added so the heatmap
             stays visible.
+        show_labels : bool, default True
+            Whether to render the numeric values inside each heatmap cell.
         Returns
         -------
         matplotlib.axes.Axes
@@ -128,6 +131,8 @@ class PlayerStatsHeatmap:
         """
 
         heatmap_data = self._prepare_data(df, team, num_games, stat)
+
+        annot = self.params["annot"] and show_labels
 
         fig, ax = plt.subplots(figsize=self.params["figsize"])
         self.fig = fig
@@ -163,7 +168,7 @@ class PlayerStatsHeatmap:
             # Square mode using seaborn heatmap
             sns.heatmap(
                 heatmap_data,
-                annot=self.params["annot"],
+                annot=annot,
                 cmap=self.params["cmap"],
                 cbar=self.params["cbar"],
                 linewidths=self.params["linewidths"],
@@ -325,7 +330,7 @@ class PlayerStatsHeatmap:
         if self.params["cbar"]:
             plt.colorbar(col, ax=ax)
 
-        if self.params["annot"]:
+        if annot:
             for i in range(len(heatmap_data.index)):
                 for j in range(len(heatmap_data.columns)):
                     if not np.isnan(heatmap_data.iloc[i, j]):

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ def read_requirements():
 
 setup(
     name="basket_viz",
-    version="0.2.6",
+    version="0.2.7",
     packages=find_packages(),
     description="A Python library for creating interactive and customizable visualizations of basketball statistics.",
     author="basket-viz",


### PR DESCRIPTION
## Summary
- add a show_labels option to plot_stat_heatmap to allow hiding numeric annotations
- pass the label toggle through circle and square heatmap renderers
- bump package version to 0.2.7

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224174e65c832b9d82bc31bd3d0d28)