### PR TITLE
Add toggle for stat grid x tick labels

### DIFF
--- a/basket_viz/stat_grid/season_stats.py
+++ b/basket_viz/stat_grid/season_stats.py
@@ -96,6 +96,7 @@ class PlayerStatsHeatmap:
         team_logo_url_lst=None,
         show=True,
         show_labels=True,
+        show_xticks=True,
     ):
         """
         Plot the heatmap of the specified stat for the players.
@@ -123,6 +124,8 @@ class PlayerStatsHeatmap:
             stays visible.
         show_labels : bool, default True
             Whether to display the x-axis label for the plot.
+        show_xticks : bool, default True
+            Whether to display the x-axis tick labels.
         Returns
         -------
         matplotlib.axes.Axes
@@ -189,6 +192,9 @@ class PlayerStatsHeatmap:
             )
         else:
             ax.set_xlabel("")
+        if not show_xticks:
+            ax.set_xticklabels([])
+            ax.tick_params(axis="x", which="both", length=0, labelbottom=False)
         plt.ylabel(
             **self.params["ylabel_title_params"],
         )


### PR DESCRIPTION
## Summary
- add a show_xticks option to the stat grid heatmap to control x-axis tick visibility
- hide x tick labels and markers when the option is disabled while keeping other labeling intact

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69224a9d4a90832b99bd3fe023ece085)